### PR TITLE
Add support for setting per-object ACLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ One of the following structs will be returned:
 - `FileStore.DownloadError`
 - `FileStore.CopyError`
 - `FileStore.RenameError`
+- `FileStore.PutAccessControlListError`
 
 Because the error implements the `Exception` behaviour, you can `raise` it.
 

--- a/lib/file_store.ex
+++ b/lib/file_store.ex
@@ -19,6 +19,8 @@ defprotocol FileStore do
   @type key :: binary()
   @type list_opts :: [{:prefix, binary()}]
   @type delete_all_opts :: [{:prefix, binary()}]
+  @type acl_list :: [term()]
+
   @type write_opts :: [
           {:content_type, binary()}
           | {:disposition, binary()}
@@ -213,4 +215,9 @@ defprotocol FileStore do
   """
   @spec list!(t, list_opts) :: Enumerable.t()
   def list!(store, opts \\ [])
+
+  @doc """
+  """
+  @spec put_access_control_list(t, key(), acl_list()) :: :ok | {:error, term}
+  def put_access_control_list(store, key, acl)
 end

--- a/lib/file_store.ex
+++ b/lib/file_store.ex
@@ -217,6 +217,16 @@ defprotocol FileStore do
   def list!(store, opts \\ [])
 
   @doc """
+  Set the access control list (ACL) for a file in the store. This is only implemented for S3.
+
+  ## Examples
+
+      iex> FileStore.put_access_control_list("foo", [{:acl, :public_read}])
+      :ok
+
+      iex> FileStore.put_access_control_list("foo", [{:grant_read, email: "foo@example.com"}])
+      :ok
+
   """
   @spec put_access_control_list(t, key(), acl_list()) :: :ok | {:error, term}
   def put_access_control_list(store, key, acl)

--- a/lib/file_store.ex
+++ b/lib/file_store.ex
@@ -219,6 +219,8 @@ defprotocol FileStore do
   @doc """
   Set the access control list (ACL) for a file in the store. This is only implemented for S3.
 
+  See https://hexdocs.pm/ex_aws_s3/ExAws.S3.html#t:acl_opt/0 for the format of the ACL list.
+
   ## Examples
 
       iex> FileStore.put_access_control_list("foo", [{:acl, :public_read}])

--- a/lib/file_store/adapters/disk.ex
+++ b/lib/file_store/adapters/disk.ex
@@ -127,6 +127,8 @@ defmodule FileStore.Adapters.Disk do
            do: File.rename(src, dest)
     end
 
+    def put_access_control_list(_store, _key, _acl), do: :ok
+
     def upload(store, source, key) do
       with {:ok, dest} <- expand(store, key),
            {:ok, _} <- File.copy(source, dest),

--- a/lib/file_store/adapters/memory.ex
+++ b/lib/file_store/adapters/memory.ex
@@ -154,6 +154,8 @@ defmodule FileStore.Adapters.Memory do
       end)
     end
 
+    def put_access_control_list(_store, _key, _acl), do: :ok
+
     def upload(store, source, key) do
       with {:ok, data} <- File.read(source) do
         write(store, key, data)

--- a/lib/file_store/adapters/null.ex
+++ b/lib/file_store/adapters/null.ex
@@ -49,6 +49,7 @@ defmodule FileStore.Adapters.Null do
     def read(_store, _key), do: {:ok, ""}
     def copy(_store, _src, _dest), do: :ok
     def rename(_store, _src, _dest), do: :ok
+    def put_access_control_list(_store, _key, _acl), do: :ok
     def list!(_store, _opts), do: Stream.into([], [])
   end
 end

--- a/lib/file_store/adapters/s3.ex
+++ b/lib/file_store/adapters/s3.ex
@@ -169,6 +169,12 @@ if Code.ensure_loaded?(ExAws.S3) do
         end
       end
 
+      def put_access_control_list(store, key, acl) do
+        store.bucket
+        |> ExAws.S3.put_object_acl(key, acl)
+        |> acknowledge(store)
+      end
+
       defp request(op, store) do
         ExAws.request(op, store.ex_aws)
       end

--- a/lib/file_store/config.ex
+++ b/lib/file_store/config.ex
@@ -102,6 +102,11 @@ defmodule FileStore.Config do
         FileStore.rename(new(), src, dest)
       end
 
+      @spec put_access_control_list(FileStore.key(), String.t()) :: :ok | {:error, term()}
+      def put_access_control_list(key, acl) do
+        FileStore.put_access_control_list(new(), key, acl)
+      end
+
       @spec upload(Path.t(), binary()) :: :ok | {:error, term()}
       def upload(source, key) do
         FileStore.upload(new(), source, key)

--- a/lib/file_store/error.ex
+++ b/lib/file_store/error.ex
@@ -52,6 +52,16 @@ defmodule FileStore.CopyError do
   end
 end
 
+defmodule FileStore.PutAccessControlListError do
+  defexception [:key, :acl]
+
+  @impl true
+  def message(%{reason: reason, key: key, acl: acl}) do
+    reason = FileStore.Error.format(reason)
+    "could not set the access control list of #{inspect(key)} to #{inspect(acl)}: #{reason}"
+  end
+end
+
 defmodule FileStore.RenameError do
   defexception [:reason, :src, :dest]
 

--- a/lib/file_store/middleware/errors.ex
+++ b/lib/file_store/middleware/errors.ex
@@ -9,6 +9,7 @@ defmodule FileStore.Middleware.Errors do
     * `FileStore.DownloadError`
     * `FileStore.CopyError`
     * `FileStore.RenameError`
+    * `FileStore.PutAccessControlListError`
 
   Each of these structs contain `reason` field, where you'll find the original
   error that was returned by the underlying adapter.
@@ -39,6 +40,7 @@ defmodule FileStore.Middleware.Errors do
     alias FileStore.DownloadError
     alias FileStore.RenameError
     alias FileStore.CopyError
+    alias FileStore.PutAccessControlListError
 
     def stat(store, key) do
       store.__next__
@@ -68,6 +70,12 @@ defmodule FileStore.Middleware.Errors do
       store.__next__
       |> FileStore.rename(src, dest)
       |> wrap(RenameError, src: src, dest: dest)
+    end
+
+    def put_access_control_list(store, key, acl) do
+      store.__next__
+      |> FileStore.put_access_control_list(key, acl)
+      |> wrap(PutAccessControlListError, key: key, acl: acl)
     end
 
     def upload(store, path, key) do

--- a/lib/file_store/middleware/logger.ex
+++ b/lib/file_store/middleware/logger.ex
@@ -45,6 +45,12 @@ defmodule FileStore.Middleware.Logger do
       |> log("RENAME", src: src, dest: dest)
     end
 
+    def put_access_control_list(store, key, acl) do
+      store.__next__
+      |> FileStore.put_access_control_list(key, acl)
+      |> log("PUT_ACCESS_CONTROL_LIST", key: key, acl: acl)
+    end
+
     def upload(store, source, key) do
       store.__next__
       |> FileStore.upload(source, key)

--- a/lib/file_store/middleware/prefix.ex
+++ b/lib/file_store/middleware/prefix.ex
@@ -54,6 +54,10 @@ defmodule FileStore.Middleware.Prefix do
       FileStore.rename(store.__next__, put_prefix(src, store), put_prefix(dest, store))
     end
 
+    def put_access_control_list(store, key, acl) do
+      FileStore.put_access_control_list(store.__next__, put_prefix(key, store), acl)
+    end
+
     def upload(store, source, key) do
       FileStore.upload(store.__next__, source, put_prefix(key, store))
     end

--- a/test/support/adapter_case.ex
+++ b/test/support/adapter_case.ex
@@ -208,6 +208,14 @@ defmodule FileStore.AdapterCase do
           assert {:ok, _} = FileStore.stat(store, "bar")
         end
       end
+
+      describe "put_access_control_list/4 conformance" do
+        test "updates the access control list on the object", %{store: store} do
+          :ok = FileStore.write(store, "foo", "test")
+
+          assert :ok = FileStore.put_access_control_list(store, "foo", [{:acl, :private}])
+        end
+      end
     end
   end
 

--- a/test/support/error_adapter.ex
+++ b/test/support/error_adapter.ex
@@ -17,6 +17,7 @@ defmodule FileStore.Adapters.Error do
     def delete_all(_store, _opts \\ []), do: {:error, :boom}
     def copy(_store, _src, _dest), do: {:error, :boom}
     def rename(_store, _src, _dest), do: {:error, :boom}
+    def put_access_control_list(_store, _key, _acl), do: {:error, :boom}
     def get_public_url(_store, key, _opts \\ []), do: key
     def get_signed_url(_store, _key, _opts \\ []), do: {:error, :boom}
     def list!(_store, _opts \\ []), do: []


### PR DESCRIPTION
Allows setting per object ACLs in S3. This can be used to set per object access using canned S3 ACLs such as "public_read" or "private" or specific read/write grants to individual users.

S3 ACL reference: https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html