### PR TITLE
Add Object Tagging

### DIFF
--- a/lib/file_store.ex
+++ b/lib/file_store.ex
@@ -232,4 +232,7 @@ defprotocol FileStore do
   """
   @spec put_access_control_list(t, key(), acl_list()) :: :ok | {:error, term}
   def put_access_control_list(store, key, acl)
+
+  def set_tags(store, key, tags)
+  def get_tags(store, key)
 end

--- a/lib/file_store/adapters/disk.ex
+++ b/lib/file_store/adapters/disk.ex
@@ -129,6 +129,9 @@ defmodule FileStore.Adapters.Disk do
 
     def put_access_control_list(_store, _key, _acl), do: :ok
 
+    def set_tags(_store, _key, _tags), do: :ok
+    def get_tags(_store, _key), do: []
+
     def upload(store, source, key) do
       with {:ok, dest} <- expand(store, key),
            {:ok, _} <- File.copy(source, dest),

--- a/lib/file_store/adapters/null.ex
+++ b/lib/file_store/adapters/null.ex
@@ -50,6 +50,8 @@ defmodule FileStore.Adapters.Null do
     def copy(_store, _src, _dest), do: :ok
     def rename(_store, _src, _dest), do: :ok
     def put_access_control_list(_store, _key, _acl), do: :ok
+    def set_tags(_store, _key, _tags), do: :ok
+    def get_tags(_store, _key), do: []
     def list!(_store, _opts), do: Stream.into([], [])
   end
 end

--- a/lib/file_store/adapters/s3.ex
+++ b/lib/file_store/adapters/s3.ex
@@ -175,6 +175,32 @@ if Code.ensure_loaded?(ExAws.S3) do
         |> acknowledge(store)
       end
 
+      def set_tags(store, key, tags) do
+        store.bucket
+        |> ExAws.S3.put_object_tagging(key, tags)
+        |> acknowledge(store)
+      end
+
+      def get_tags(store, key) do
+        store.bucket
+        |> ExAws.S3.get_object_tagging(key)
+        |> request(store)
+        |> case do
+          {:ok, %{body: %{tags: tags}}} ->
+            tags =
+              tags
+              |> Enum.map(fn %{key: key, value: value} ->
+                {key, value}
+              end)
+              |> Enum.into(%{})
+
+            {:ok, tags}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+      end
+
       defp request(op, store) do
         ExAws.request(op, store.ex_aws)
       end

--- a/lib/file_store/config.ex
+++ b/lib/file_store/config.ex
@@ -102,7 +102,8 @@ defmodule FileStore.Config do
         FileStore.rename(new(), src, dest)
       end
 
-      @spec put_access_control_list(FileStore.key(), String.t()) :: :ok | {:error, term()}
+      @spec put_access_control_list(FileStore.key(), FileStore.acl_list()) ::
+              :ok | {:error, term()}
       def put_access_control_list(key, acl) do
         FileStore.put_access_control_list(new(), key, acl)
       end
@@ -130,6 +131,14 @@ defmodule FileStore.Config do
       @spec list! :: Enumerable.t()
       def list!(opts \\ []) do
         FileStore.list!(new(), opts)
+      end
+
+      def set_tags(key, tags) do
+        FileStore.set_tags(new(), key, tags)
+      end
+
+      def get_tags(key) do
+        FileStore.get_tags(new(), key)
       end
     end
   end

--- a/lib/file_store/error.ex
+++ b/lib/file_store/error.ex
@@ -71,3 +71,23 @@ defmodule FileStore.RenameError do
     "could not rename #{inspect(src)} to #{inspect(dest)}: #{reason}"
   end
 end
+
+defmodule FileStore.SetTagsError do
+  defexception [:reason, :key, :tags]
+
+  @impl true
+  def message(%{reason: reason, key: key, tags: tags}) do
+    reason = FileStore.Error.format(reason)
+    "could not set tags #{inspect(tags)} for key #{inspect(key)}: #{reason}"
+  end
+end
+
+defmodule FileStore.GetTagsError do
+  defexception [:reason, :key]
+
+  @impl true
+  def message(%{reason: reason, key: key}) do
+    reason = FileStore.Error.format(reason)
+    "could not get tags for key #{inspect(key)}: #{reason}"
+  end
+end

--- a/lib/file_store/middleware/errors.ex
+++ b/lib/file_store/middleware/errors.ex
@@ -41,6 +41,8 @@ defmodule FileStore.Middleware.Errors do
     alias FileStore.RenameError
     alias FileStore.CopyError
     alias FileStore.PutAccessControlListError
+    alias FileStore.SetTagsError
+    alias FileStore.GetTagsError
 
     def stat(store, key) do
       store.__next__
@@ -76,6 +78,18 @@ defmodule FileStore.Middleware.Errors do
       store.__next__
       |> FileStore.put_access_control_list(key, acl)
       |> wrap(PutAccessControlListError, key: key, acl: acl)
+    end
+
+    def set_tags(store, key, tags) do
+      store.__next__
+      |> FileStore.set_tags(key, tags)
+      |> wrap(SetTagsError)
+    end
+
+    def get_tags(store, key) do
+      store.__next__
+      |> FileStore.get_tags(key)
+      |> wrap(GetTagsError)
     end
 
     def upload(store, path, key) do

--- a/lib/file_store/middleware/logger.ex
+++ b/lib/file_store/middleware/logger.ex
@@ -51,6 +51,14 @@ defmodule FileStore.Middleware.Logger do
       |> log("PUT_ACCESS_CONTROL_LIST", key: key, acl: acl)
     end
 
+    def set_tags(store, key, tags) do
+      FileStore.set_tags(store.__next__, key, tags)
+    end
+
+    def get_tags(store, key) do
+      FileStore.get_tags(store.__next__, key)
+    end
+
     def upload(store, source, key) do
       store.__next__
       |> FileStore.upload(source, key)

--- a/lib/file_store/middleware/prefix.ex
+++ b/lib/file_store/middleware/prefix.ex
@@ -58,6 +58,14 @@ defmodule FileStore.Middleware.Prefix do
       FileStore.put_access_control_list(store.__next__, put_prefix(key, store), acl)
     end
 
+    def set_tags(store, key, tags) do
+      FileStore.set_tags(store.__next__, put_prefix(key, store), tags)
+    end
+
+    def get_tags(store, key) do
+      FileStore.get_tags(store.__next__, put_prefix(key, store))
+    end
+
     def upload(store, source, key) do
       FileStore.upload(store.__next__, source, put_prefix(key, store))
     end

--- a/test/file_store/adapters/memory_test.exs
+++ b/test/file_store/adapters/memory_test.exs
@@ -25,4 +25,12 @@ defmodule FileStore.Adapters.MemoryTest do
     assert get_query(url, "content_type") == "text/plain"
     assert get_query(url, "disposition") == "attachment"
   end
+
+  test "set_tags/3 and get_tags/2", %{store: store} do
+    tags = %{"tag1" => "value1", "tag2" => "value2"}
+
+    assert :ok = FileStore.write(store, "foo", "content")
+    assert :ok = FileStore.set_tags(store, "foo", tags)
+    assert {:ok, ^tags} = FileStore.get_tags(store, "foo")
+  end
 end

--- a/test/file_store/adapters/s3_test.exs
+++ b/test/file_store/adapters/s3_test.exs
@@ -70,6 +70,16 @@ defmodule FileStore.Adapters.S3Test do
     end
   end
 
+  describe "set_tags/3" do
+    test "adds tags to the object", %{store: store} do
+      :ok = FileStore.write(store, "key", "test")
+
+      assert :ok = FileStore.set_tags(store, "key", [{"tag", "value"}])
+
+      assert {:ok, %{"tag" => "value"}} = FileStore.get_tags(store, "key")
+    end
+  end
+
   defp prepare_bucket! do
     @bucket
     |> ExAws.S3.put_bucket(@region)

--- a/test/support/error_adapter.ex
+++ b/test/support/error_adapter.ex
@@ -18,6 +18,8 @@ defmodule FileStore.Adapters.Error do
     def copy(_store, _src, _dest), do: {:error, :boom}
     def rename(_store, _src, _dest), do: {:error, :boom}
     def put_access_control_list(_store, _key, _acl), do: {:error, :boom}
+    def set_tags(_store, _key, _tags), do: {:error, :boom}
+    def get_tags(_store, _key), do: {:error, :boom}
     def get_public_url(_store, key, _opts \\ []), do: key
     def get_signed_url(_store, _key, _opts \\ []), do: {:error, :boom}
     def list!(_store, _opts \\ []), do: []


### PR DESCRIPTION
Adds object tagging to the file-store interface and implements it for the S3 adapter and the in-memory adapter.