### PR TITLE
Improve Error Handling for Tagging and `delete_all`

### DIFF
--- a/lib/file_store/adapters/s3.ex
+++ b/lib/file_store/adapters/s3.ex
@@ -105,9 +105,15 @@ if Code.ensure_loaded?(ExAws.S3) do
       end
 
       def delete_all(store, opts) do
-        store.bucket
-        |> ExAws.S3.delete_all_objects(list!(store, opts))
-        |> acknowledge(store)
+        keys = list!(store, opts)
+
+        if Enum.any?(keys) do
+          store.bucket
+          |> ExAws.S3.delete_all_objects(keys)
+          |> acknowledge(store)
+        else
+          :ok
+        end
       rescue
         error -> {:error, error}
       end

--- a/lib/file_store/middleware/errors.ex
+++ b/lib/file_store/middleware/errors.ex
@@ -10,6 +10,8 @@ defmodule FileStore.Middleware.Errors do
     * `FileStore.CopyError`
     * `FileStore.RenameError`
     * `FileStore.PutAccessControlListError`
+    * `FileStore.SetTagsError`
+    * `FileStore.GetTagsError`
 
   Each of these structs contain `reason` field, where you'll find the original
   error that was returned by the underlying adapter.
@@ -83,13 +85,13 @@ defmodule FileStore.Middleware.Errors do
     def set_tags(store, key, tags) do
       store.__next__
       |> FileStore.set_tags(key, tags)
-      |> wrap(SetTagsError)
+      |> wrap(SetTagsError, key: key, tags: tags)
     end
 
     def get_tags(store, key) do
       store.__next__
       |> FileStore.get_tags(key)
-      |> wrap(GetTagsError)
+      |> wrap(GetTagsError, key: key)
     end
 
     def upload(store, path, key) do

--- a/test/file_store/adapters/s3_test.exs
+++ b/test/file_store/adapters/s3_test.exs
@@ -70,6 +70,17 @@ defmodule FileStore.Adapters.S3Test do
     end
   end
 
+  describe "delete_all/1" do
+    test "returns :ok when bucket is empty", %{store: store} do
+      assert :ok = FileStore.delete_all(store)
+    end
+
+    test "returns :ok when prefix matches no keys", %{store: store} do
+      assert :ok = FileStore.write(store, "foo", "bar")
+      assert :ok = FileStore.delete_all(store, prefix: "non-existent")
+    end
+  end
+
   describe "set_tags/3" do
     test "adds tags to the object", %{store: store} do
       :ok = FileStore.write(store, "key", "test")

--- a/test/file_store/middleware/errors_test.exs
+++ b/test/file_store/middleware/errors_test.exs
@@ -126,5 +126,24 @@ defmodule FileStore.Middleware.ErrorsTest do
 
       assert {:error, ^error} = FileStore.get_signed_url(store, "key")
     end
+
+    test "set_tags/3", %{store: store} do
+      error = %FileStore.SetTagsError{
+        key: "key",
+        tags: [{"tag", "value"}],
+        reason: :boom
+      }
+
+      assert {:error, ^error} = FileStore.set_tags(store, "key", [{"tag", "value"}])
+    end
+
+    test "get_tags/2", %{store: store} do
+      error = %FileStore.GetTagsError{
+        key: "key",
+        reason: :boom
+      }
+
+      assert {:error, ^error} = FileStore.get_tags(store, "key")
+    end
   end
 end


### PR DESCRIPTION
This pull request improves error handling in the S3 adapter and error middleware for tag-related operations and deleting objects.

**Error Handling Improvements:**

* Added `FileStore.SetTagsError` and `FileStore.GetTagsError` to the documented list of possible errors in the middleware, and updated the `wrap` function calls for `set_tags/3` and `get_tags/2` to include relevant context (`key` and `tags`) in the error struct. Prior to this change, without that additional metadata, it was causing a FunctionClause error.

**S3 Adapter Robustness:**

* Updated the `delete_all/2` function in `S3` adapter to return `:ok` immediately if there are no keys to delete, avoiding an S3 error when trying to delete nothing.

**Testing Enhancements:**

* Added tests to verify that `delete_all/1` returns `:ok` when the bucket is empty or when the prefix matches no keys.
* Added tests for the new `set_tags/3` and `get_tags/2` error handling, confirming that errors are wrapped with the correct context and do not raise a FunctionClause error.